### PR TITLE
Incorporate ScatterMoE 

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,171 @@
+import os
+import torch
+from functools import partial
+from tqdm import trange
+import time
+
+try:
+    from fms_acceleration_moe.utils.scattermoe import ScatterMoE, ScatteredExperts, SCATTERMOE_SPEC_HAS_GATE
+    HAS_SCATTERMOE = True
+except ImportError:
+    HAS_SCATTERMOE = False
+
+from transformers.models.granitemoe.modeling_granitemoe import GraniteMoeConfig, GraniteMoeMoE
+
+from mamba_ssm.models.mixer_seq_simple import _init_weights
+
+def benchmark_kernels(
+    d_model: int,
+    d_intermediate: int,
+    n_expert: int,
+    top_k: int,
+    batch_size: int = 4,
+    seq_len: int = 4096,
+    device: str = 'cuda',
+    dtype: str = 'bfloat16',
+    warmup: int = 10,
+    runs: int = 50,
+    seed: int = 42,
+    check_correctness: bool = True,
+):
+    torch.manual_seed(seed)
+
+    scattermoe = ScatterMoE(
+        hidden_size=d_model,
+        hidden_act='silu',
+        intermediate_size=d_intermediate,
+        num_experts=n_expert,
+        has_bias=False, # hardcode this, scattermoe cannot work with bias
+        mlp_arch=SCATTERMOE_SPEC_HAS_GATE, # hardcode this, use gated
+        top_k=top_k,
+        device=device,
+        dtype=getattr(torch, dtype),
+    )
+    # _init_weights(scattermoe, 1, rescale_prenorm_residual=False)
+    scattermoe.apply(
+        partial(
+            _init_weights,
+            n_layer=1,
+            rescale_prenorm_residual=False
+        )
+    )
+
+    config = GraniteMoeConfig(
+        hidden_size=d_model,
+        intermediate_size=d_intermediate,
+        hidden_act='silu',
+        num_local_experts=n_expert,
+        num_experts_per_tok=top_k,
+        output_router_logits=True,
+    )
+    naive = GraniteMoeMoE(config).to(device=device, dtype=getattr(torch, dtype))
+    naive.router.layer.weight.data = scattermoe.router.weight.data.clone()
+    naive.input_linear.weight.data = torch.cat(
+        [
+            scattermoe.w1.weight.data.transpose(1,2).clone(),
+            scattermoe.w3.weight.data.transpose(1,2).clone(),
+        ], dim=1
+    )
+    naive.output_linear.weight.data = scattermoe.w2.weight.data.transpose(1,2).clone()
+
+    tol = {'atol': 5e-2, 'rtol': 2e-2}
+
+    input_scatter = torch.randn((batch_size, seq_len, d_model), device=device, dtype=getattr(torch, dtype))
+    input_scatter.requires_grad = True
+    input_naive = input_scatter.clone()
+    input_naive.retain_grad()
+
+
+    def _run_scatter(input):
+        scattermoe.router.weight.grad = None
+        scattermoe.w1.weight.grad = None
+        scattermoe.w2.weight.grad = None
+        scattermoe.w3.weight.grad = None
+        input.grad = None
+        output, logits = scattermoe(input)
+        output.norm().backward()
+        return output, logits
+
+    def _run_naive(input):
+        naive.router.layer.weight.grad = None
+        naive.input_linear.weight.grad = None
+        naive.output_linear.weight.grad = None
+        input.grad = None
+        output, logits = naive(input)
+        output.norm().backward()
+        return output, logits
+
+
+    # warmup
+    try:
+        distribution = None
+        for i in trange(warmup):
+            output_scatter, logits_scatter = _run_scatter(input_scatter)
+            output_naive, logits_native = _run_naive(input_naive)
+
+            # count the router distribution
+            _, distribution = logits_scatter.topk(2).indices.unique(return_counts=True)
+            distribution = distribution.detach().cpu().tolist()
+
+            # do some functional checks 
+            if check_correctness and i == 0:
+                assert torch.allclose(output_scatter, output_naive, **tol)
+                assert torch.allclose(input_scatter.grad, input_naive.grad, **tol)
+                assert torch.allclose(logits_scatter.to(torch.float32), logits_native, **tol)
+
+                # this one hard to match because the naive impl casts to float
+                # assert torch.allclose(scattermoe.router.weight.grad, naive.router.layer.weight.grad, **tol)
+                assert torch.allclose(scattermoe.w2.weight.grad, naive.output_linear.weight.grad.transpose(1, 2), **tol)
+
+        t1_scatter = time.time()
+        for i in trange(runs):
+            _run_scatter(input_scatter)
+        torch.cuda.synchronize()
+        t1_scatter = time.time() - t1_scatter
+
+        t1_naive = time.time()
+        for i in trange(runs):
+            _run_naive(input_naive)
+        torch.cuda.synchronize()
+        t1_naive = time.time() - t1_naive
+        results = {
+            'time_scatter': t1_scatter, 'time_naive': t1_naive,
+            'distribution': distribution,
+        }
+    except AssertionError:
+        results = {'error': True}
+    finally:
+        del input_naive, output_naive, logits_native 
+        del input_scatter, output_scatter, logits_scatter
+        del scattermoe
+        del naive
+        torch.cuda.empty_cache()
+
+    return {
+        'd_model': d_model,
+        'd_intermediate': d_intermediate,
+        'n_expert': n_expert,
+        'top_k': top_k,
+        'batch_size': batch_size,
+        'seq_len': seq_len,
+        'dtype': dtype,
+        **results
+    }
+
+
+if __name__ == '__main__':
+
+    from itertools import product
+
+    # import fire
+    if HAS_SCATTERMOE:
+        for batch_size, n_expert in product(
+            [1, 4, 8],
+            [2, 4, 8, 16]
+        ):
+            results = benchmark_kernels(
+                4096, 14336, 
+                n_expert, 2, batch_size=batch_size, seed=1,
+                check_correctness=True
+            )
+            print (results)

--- a/mamba_ssm/models/config_mamba.py
+++ b/mamba_ssm/models/config_mamba.py
@@ -11,6 +11,7 @@ class MambaConfig:
     ssm_cfg: dict = field(default_factory=dict)
     attn_layer_idx: list = field(default_factory=list)
     attn_cfg: dict = field(default_factory=dict)
+    mlp_cfg: dict = field(default_factory=dict)
     rms_norm: bool = True
     residual_in_fp32: bool = True
     fused_add_norm: bool = True

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -70,11 +70,28 @@ def create_block(
         mlp_cls = partial(
             GatedMLP, hidden_features=d_intermediate, out_features=d_model, **factory_kwargs
         )
+
+    if True:
+        # hack in the MoE
+        from fms_acceleration_moe.utils.scattermoe import ScatterMoE, SCATTERMOE_SPEC_HAS_GATE
+        moe_cls = partial(
+            ScatterMoE,
+            hidden_size=d_model,
+            hidden_act='silu',
+            intermediate_size=int(8* d_model / 3),
+            num_experts=4,
+            has_bias=False,
+            mlp_arch=SCATTERMOE_SPEC_HAS_GATE,
+            top_k=2,
+            **factory_kwargs
+        )
+
     block = Block(
         d_model,
         mixer_cls,
         mlp_cls,
         norm_cls=norm_cls,
+        moe_cls=moe_cls,
         fused_add_norm=fused_add_norm,
         residual_in_fp32=residual_in_fp32,
     )
@@ -288,7 +305,10 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         config_data = load_config_hf(pretrained_model_name)
         config = MambaConfig(**config_data)
         model = cls(config, device=device, dtype=dtype, **kwargs)
-        model.load_state_dict(load_state_dict_hf(pretrained_model_name, device=device, dtype=dtype))
+        model.load_state_dict(
+            load_state_dict_hf(pretrained_model_name, device=device, dtype=dtype),
+            strict=False
+        )
         return model
 
     def save_pretrained(self, save_directory):

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -247,14 +247,15 @@ class MixerModel(nn.Module):
             d_model, eps=norm_epsilon, **factory_kwargs
         )
 
-        self.apply(
-            partial(
-                _init_weights,
-                n_layer=n_layer,
-                **(initializer_cfg if initializer_cfg is not None else {}),
-                n_residuals_per_layer=1 if d_intermediate == 0 else 2,  # 2 if we have MLP
+        if initializer_cfg:
+            self.apply(
+                partial(
+                    _init_weights,
+                    n_layer=n_layer,
+                    **(initializer_cfg if initializer_cfg is not None else {}),
+                    n_residuals_per_layer=1 if d_intermediate == 0 else 2,  # 2 if we have MLP
+                )
             )
-        )
 
     def allocate_inference_cache(self, batch_size, max_seqlen, dtype=None, **kwargs):
         return {
@@ -341,13 +342,14 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         self.lm_head = nn.Linear(d_model, vocab_size, bias=False, **factory_kwargs)
 
         # Initialize weights and apply final processing
-        self.apply(
-            partial(
-                _init_weights,
-                n_layer=n_layer,
-                **(initializer_cfg if initializer_cfg is not None else {}),
+        if initializer_cfg:
+            self.apply(
+                partial(
+                    _init_weights,
+                    n_layer=n_layer,
+                    **(initializer_cfg if initializer_cfg is not None else {}),
+                )
             )
-        )
         self.tie_weights()
 
     def tie_weights(self):
@@ -378,11 +380,16 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
     def from_pretrained(cls, pretrained_model_name, device=None, dtype=None, **kwargs):
         config_data = load_config_hf(pretrained_model_name)
         config = MambaConfig(**config_data)
+        low_cpu_mem_mode = kwargs.pop("low_cpu_mem_mode", False)
         model = cls(config, device=device, dtype=dtype, **kwargs)
-        model.load_state_dict(
-            load_state_dict_hf(pretrained_model_name, device=device, dtype=dtype),
-            strict=False
-        )
+
+        # when using low_cpu_mem_mode, try to set to True to avoid
+        # loading the state dict if the model is on meta device
+        if not low_cpu_mem_mode:
+            model.load_state_dict(
+                load_state_dict_hf(pretrained_model_name, device=device, dtype=dtype),
+                strict=False
+            )
         return model
 
     def save_pretrained(self, save_directory):

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -25,6 +25,17 @@ try:
 except ImportError:
     RMSNorm, layer_norm_fn, rms_norm_fn = None, None, None
 
+import warnings
+
+HAS_SCATTERMOE = False
+try:
+    from fms_acceleration_moe.utils.scattermoe import ScatterMoE, SCATTERMOE_SPEC_HAS_GATE
+    # breadcrumb
+    ScatterMoE._disable_load_balance_loss = False
+    HAS_SCATTERMOE = True
+except ImportError:
+    pass
+
 
 def create_block(
     d_model,
@@ -32,6 +43,7 @@ def create_block(
     ssm_cfg=None,
     attn_layer_idx=None,
     attn_cfg=None,
+    mlp_cfg=None,
     norm_epsilon=1e-5,
     rms_norm=False,
     residual_in_fp32=False,
@@ -46,6 +58,14 @@ def create_block(
         attn_layer_idx = []
     if attn_cfg is None:
         attn_cfg = {}
+    if mlp_cfg is None:
+        # TODO: hardcode
+        mlp_cfg = {}
+        # mlp_cfg = {
+        #     'n_expert': 4,
+        #     'load_balancing_loss': True,
+        # }
+
     factory_kwargs = {"device": device, "dtype": dtype}
     if layer_idx not in attn_layer_idx:
         # Create a copy of the config to modify
@@ -66,23 +86,39 @@ def create_block(
     )
     if d_intermediate == 0:
         mlp_cls = nn.Identity
-    else:
+    elif len(mlp_cfg) == 0:
         mlp_cls = partial(
             GatedMLP, hidden_features=d_intermediate, out_features=d_model, **factory_kwargs
         )
+    else:
+        assert HAS_SCATTERMOE, "MoE requires scattermoe"
 
-    if True:
-        # hack in the MoE
-        from fms_acceleration_moe.utils.scattermoe import ScatterMoE, SCATTERMOE_SPEC_HAS_GATE
-        moe_cls = partial(
+        if (
+            mlp_cfg.get('load_balancing_loss', False) == False and
+            ScatterMoE._disable_load_balance_loss == False
+        ):
+            # to handle the load balancing loss
+            _old_scattermoe_forward = ScatterMoE.forward
+            def _scattermoe_forward(self, hidden_states: torch.Tensor):
+                hidden_states, _ = _old_scattermoe_forward(self, hidden_states)
+                return hidden_states
+            ScatterMoE.forward = _scattermoe_forward
+            ScatterMoE._disable_load_balance_loss = True
+            warnings.warn(
+                "Disabled returning of router logits for ScatterMoE. "
+                "To renable requires reload of module."
+            )
+
+        mlp_cls = partial(
             ScatterMoE,
-            hidden_size=d_model,
+            # hidden_size=d_model,
             hidden_act='silu',
-            intermediate_size=int(8* d_model / 3),
-            num_experts=4,
-            has_bias=False,
-            mlp_arch=SCATTERMOE_SPEC_HAS_GATE,
-            top_k=2,
+            # intermediate_size=int(8* d_model / 3),
+            intermediate_size=d_intermediate,
+            num_experts=mlp_cfg['n_expert'],
+            has_bias=False, # hardcode this, scattermoe cannot work with bias
+            mlp_arch=SCATTERMOE_SPEC_HAS_GATE, # hardcode this, use gated
+            top_k=mlp_cfg.get('top_k', 2),
             **factory_kwargs
         )
 
@@ -91,7 +127,6 @@ def create_block(
         mixer_cls,
         mlp_cls,
         norm_cls=norm_cls,
-        moe_cls=moe_cls,
         fused_add_norm=fused_add_norm,
         residual_in_fp32=residual_in_fp32,
     )
@@ -142,6 +177,7 @@ class MixerModel(nn.Module):
         ssm_cfg=None,
         attn_layer_idx=None,
         attn_cfg=None,
+        mlp_cfg=None,
         norm_epsilon: float = 1e-5,
         rms_norm: bool = False,
         initializer_cfg=None,
@@ -179,6 +215,7 @@ class MixerModel(nn.Module):
                     residual_in_fp32=residual_in_fp32,
                     fused_add_norm=fused_add_norm,
                     layer_idx=i,
+                    mlp_cfg=mlp_cfg,
                     **factory_kwargs,
                 )
                 for i in range(n_layer)
@@ -207,10 +244,23 @@ class MixerModel(nn.Module):
     def forward(self, input_ids, inference_params=None, **mixer_kwargs):
         hidden_states = self.embedding(input_ids)
         residual = None
+        outputs = tuple()
         for layer in self.layers:
             hidden_states, residual = layer(
                 hidden_states, residual, inference_params=inference_params, **mixer_kwargs
             )
+            # if MoE
+            if isinstance(hidden_states, tuple):
+                # from transformers.models.granitemoe.modeling_granitemoe import load_balancing_loss_func
+                hidden_states, aux_outputs = hidden_states
+                # aux_loss = (
+                #     aux_loss + 
+                #     load_balancing_loss_func(
+                #         gate_logits
+                #     )
+                # )
+                outputs = outputs + (aux_outputs, )
+
         if not self.fused_add_norm:
             residual = (hidden_states + residual) if residual is not None else hidden_states
             hidden_states = self.norm_f(residual.to(dtype=self.norm_f.weight.dtype))
@@ -226,6 +276,9 @@ class MixerModel(nn.Module):
                 residual_in_fp32=self.residual_in_fp32,
                 is_rms_norm=isinstance(self.norm_f, RMSNorm)
             )
+
+        if len(outputs) > 0:
+            return hidden_states, outputs
         return hidden_states
 
 
@@ -241,6 +294,7 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         self.config = config
         d_model = config.d_model
         n_layer = config.n_layer
+        mlp_cfg = config.mlp_cfg
         d_intermediate = config.d_intermediate
         vocab_size = config.vocab_size
         ssm_cfg = config.ssm_cfg
@@ -263,6 +317,7 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
             ssm_cfg=ssm_cfg,
             attn_layer_idx=attn_layer_idx,
             attn_cfg=attn_cfg,
+            mlp_cfg=mlp_cfg,
             rms_norm=rms_norm,
             initializer_cfg=initializer_cfg,
             fused_add_norm=fused_add_norm,
@@ -293,12 +348,17 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         "position_ids" is just to be compatible with Transformer generation. We don't use it.
         num_last_tokens: if > 0, only return the logits for the last n tokens
         """
+        aux_outputs = None
         hidden_states = self.backbone(input_ids, inference_params=inference_params, **mixer_kwargs)
+        if isinstance(hidden_states, tuple):
+            hidden_states, aux_outputs = hidden_states
         if num_last_tokens > 0:
             hidden_states = hidden_states[:, -num_last_tokens:]
         lm_logits = self.lm_head(hidden_states)
-        CausalLMOutput = namedtuple("CausalLMOutput", ["logits"])
-        return CausalLMOutput(logits=lm_logits)
+        CausalLMOutput = namedtuple(
+            "CausalLMOutput", ["logits", "aux_outputs"]
+        )
+        return CausalLMOutput(logits=lm_logits, aux_outputs=aux_outputs)
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name, device=None, dtype=None, **kwargs):

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -29,12 +29,15 @@ import warnings
 
 HAS_SCATTERMOE = False
 try:
+    if os.environ.get("DISABLE_SCATTERMOE", "False") == "True":
+        warnings.warn("DISABLE_SCATTERMOE=True so disabling ScatterMoE")
+        raise ImportError("Disabling ScatterMoE") 
     from fms_acceleration_moe.utils.scattermoe import ScatterMoE, ScatteredExperts, SCATTERMOE_SPEC_HAS_GATE
     # breadcrumb
     ScatterMoE._disable_load_balance_loss = False
     HAS_SCATTERMOE = True
 except ImportError:
-    pass
+    from transformers.models.granitemoe.modeling_granitemoe import GraniteMoeConfig, GraniteMoeMoE
 
 
 def create_block(
@@ -59,12 +62,7 @@ def create_block(
     if attn_cfg is None:
         attn_cfg = {}
     if mlp_cfg is None:
-        # TODO: hardcode
         mlp_cfg = {}
-        # mlp_cfg = {
-        #     'n_expert': 4,
-        #     'load_balancing_loss': True,
-        # }
 
     factory_kwargs = {"device": device, "dtype": dtype}
     if layer_idx not in attn_layer_idx:
@@ -91,36 +89,57 @@ def create_block(
             GatedMLP, hidden_features=d_intermediate, out_features=d_model, **factory_kwargs
         )
     else:
-        assert HAS_SCATTERMOE, "MoE requires scattermoe"
 
-        if (
-            mlp_cfg.get('load_balancing_loss', False) == False and
-            ScatterMoE._disable_load_balance_loss == False
-        ):
-            # to handle the load balancing loss
-            _old_scattermoe_forward = ScatterMoE.forward
-            def _scattermoe_forward(self, hidden_states: torch.Tensor):
-                hidden_states, _ = _old_scattermoe_forward(self, hidden_states)
-                return hidden_states
-            ScatterMoE.forward = _scattermoe_forward
-            ScatterMoE._disable_load_balance_loss = True
-            warnings.warn(
-                "Disabled returning of router logits for ScatterMoE. "
-                "To renable requires reload of module."
+        if HAS_SCATTERMOE:
+            if (
+                mlp_cfg.get('load_balancing_loss', False) == False and
+                ScatterMoE._disable_load_balance_loss == False
+            ):
+                # to handle the load balancing loss
+                _old_scattermoe_forward = ScatterMoE.forward
+                def _scattermoe_forward(self, hidden_states: torch.Tensor):
+                    hidden_states, _ = _old_scattermoe_forward(self, hidden_states)
+                    return hidden_states
+                ScatterMoE.forward = _scattermoe_forward
+                ScatterMoE._disable_load_balance_loss = True
+                warnings.warn(
+                    "Disabled returning of router logits for ScatterMoE. "
+                    "To renable requires reload of module."
+                )
+
+            mlp_cls = partial(
+                ScatterMoE,
+                # hidden_size=d_model,
+                hidden_act='silu',
+                # intermediate_size=int(8* d_model / 3),
+                intermediate_size=d_intermediate,
+                num_experts=mlp_cfg['n_expert'],
+                has_bias=False, # hardcode this, scattermoe cannot work with bias
+                mlp_arch=SCATTERMOE_SPEC_HAS_GATE, # hardcode this, use gated
+                top_k=mlp_cfg.get('top_k', 2),
+                **factory_kwargs
             )
+        else:
+            # NOTE: just for benching against a naive 
+            # MoE implementation, not to be used for
+            # real training
 
-        mlp_cls = partial(
-            ScatterMoE,
-            # hidden_size=d_model,
-            hidden_act='silu',
-            # intermediate_size=int(8* d_model / 3),
-            intermediate_size=d_intermediate,
-            num_experts=mlp_cfg['n_expert'],
-            has_bias=False, # hardcode this, scattermoe cannot work with bias
-            mlp_arch=SCATTERMOE_SPEC_HAS_GATE, # hardcode this, use gated
-            top_k=mlp_cfg.get('top_k', 2),
-            **factory_kwargs
-        )
+            def _build_granite_moe(dim):
+                config = GraniteMoeConfig(
+                    hidden_size=dim,
+                    intermediate_size=d_intermediate,
+                    hidden_act='silu',
+                    num_local_experts=mlp_cfg['n_expert'],
+                    num_experts_per_tok=mlp_cfg.get('top_k', 2),
+                    output_router_logits=mlp_cfg.get('load_balancing_loss', False)
+                )
+                mod = GraniteMoeMoE(config)
+                if 'dtype' in factory_kwargs:
+                    mod = mod.to(factory_kwargs['dtype'])
+                if 'device' in factory_kwargs:
+                    mod = mod.to(factory_kwargs['device'])
+                return mod
+            mlp_cls = _build_granite_moe
 
     block = Block(
         d_model,
@@ -253,14 +272,7 @@ class MixerModel(nn.Module):
             )
             # if MoE
             if isinstance(hidden_states, tuple):
-                # from transformers.models.granitemoe.modeling_granitemoe import load_balancing_loss_func
                 hidden_states, aux_outputs = hidden_states
-                # aux_loss = (
-                #     aux_loss + 
-                #     load_balancing_loss_func(
-                #         gate_logits
-                #     )
-                # )
                 outputs = outputs + (aux_outputs, )
 
         if not self.fused_add_norm:

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -379,7 +379,8 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
     @classmethod
     def from_pretrained(cls, pretrained_model_name, device=None, dtype=None, **kwargs):
         config_data = load_config_hf(pretrained_model_name)
-        config = MambaConfig(**config_data)
+        config_kwargs = kwargs.pop("config_kwargs", {})
+        config = MambaConfig(**config_data, **config_kwargs)
         low_cpu_mem_mode = kwargs.pop("low_cpu_mem_mode", False)
         model = cls(config, device=device, dtype=dtype, **kwargs)
 

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -138,7 +138,7 @@ def create_block(
 def _init_weights(
     module,
     n_layer,
-    initializer_range=0.02,  # Now only used for embedding layer.
+    initializer_range=0.02,  # Used for embedding layer and (scattermoe).
     rescale_prenorm_residual=True,
     n_residuals_per_layer=1,  # Change to 2 if we have MLP
 ):
@@ -149,7 +149,7 @@ def _init_weights(
     elif isinstance(module, nn.Embedding):
         nn.init.normal_(module.weight, std=initializer_range)
     elif HAS_SCATTERMOE and isinstance(module, ScatteredExperts):
-        nn.init.normal_(module.weight)
+        nn.init.normal_(module.weight, std=initializer_range)
 
     if rescale_prenorm_residual:
         # Reinitialize selected weights subject to the OpenAI GPT-2 Paper Scheme:

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -29,7 +29,7 @@ import warnings
 
 HAS_SCATTERMOE = False
 try:
-    from fms_acceleration_moe.utils.scattermoe import ScatterMoE, SCATTERMOE_SPEC_HAS_GATE
+    from fms_acceleration_moe.utils.scattermoe import ScatterMoE, ScatteredExperts, SCATTERMOE_SPEC_HAS_GATE
     # breadcrumb
     ScatterMoE._disable_load_balance_loss = False
     HAS_SCATTERMOE = True
@@ -148,6 +148,8 @@ def _init_weights(
                 nn.init.zeros_(module.bias)
     elif isinstance(module, nn.Embedding):
         nn.init.normal_(module.weight, std=initializer_range)
+    elif HAS_SCATTERMOE and isinstance(module, ScatteredExperts):
+        nn.init.normal_(module.weight)
 
     if rescale_prenorm_residual:
         # Reinitialize selected weights subject to the OpenAI GPT-2 Paper Scheme:

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -247,15 +247,14 @@ class MixerModel(nn.Module):
             d_model, eps=norm_epsilon, **factory_kwargs
         )
 
-        if initializer_cfg:
-            self.apply(
-                partial(
-                    _init_weights,
-                    n_layer=n_layer,
-                    **(initializer_cfg if initializer_cfg is not None else {}),
-                    n_residuals_per_layer=1 if d_intermediate == 0 else 2,  # 2 if we have MLP
-                )
+        self.apply(
+            partial(
+                _init_weights,
+                n_layer=n_layer,
+                **(initializer_cfg if initializer_cfg is not None else {}),
+                n_residuals_per_layer=1 if d_intermediate == 0 else 2,  # 2 if we have MLP
             )
+        )
 
     def allocate_inference_cache(self, batch_size, max_seqlen, dtype=None, **kwargs):
         return {
@@ -342,14 +341,13 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         self.lm_head = nn.Linear(d_model, vocab_size, bias=False, **factory_kwargs)
 
         # Initialize weights and apply final processing
-        if initializer_cfg:
-            self.apply(
-                partial(
-                    _init_weights,
-                    n_layer=n_layer,
-                    **(initializer_cfg if initializer_cfg is not None else {}),
-                )
+        self.apply(
+            partial(
+                _init_weights,
+                n_layer=n_layer,
+                **(initializer_cfg if initializer_cfg is not None else {}),
             )
+        )
         self.tie_weights()
 
     def tie_weights(self):

--- a/mamba_ssm/modules/block.py
+++ b/mamba_ssm/modules/block.py
@@ -10,8 +10,7 @@ from mamba_ssm.ops.triton.layer_norm import RMSNorm, layer_norm_fn
 class Block(nn.Module):
     def __init__(
         self, dim, mixer_cls, mlp_cls, 
-        moe_cls=None,
-        norm_cls=nn.LayerNorm, fused_add_norm=False, residual_in_fp32=False
+        norm_cls=nn.LayerNorm, fused_add_norm=False, residual_in_fp32=False,
     ):
         """
         Simple block wrapping a mixer class with LayerNorm/RMSNorm and residual connection"
@@ -35,11 +34,6 @@ class Block(nn.Module):
             self.mlp = mlp_cls(dim)
         else:
             self.mlp = None
-
-        # hack in the MoE
-        if moe_cls:
-            self.norm2 = norm_cls(dim)
-            self.moe = moe_cls()
 
         if self.fused_add_norm:
             assert RMSNorm is not None, "RMSNorm import fails"
@@ -74,7 +68,7 @@ class Block(nn.Module):
             )
         hidden_states = self.mixer(hidden_states, inference_params=inference_params, **mixer_kwargs)
 
-        if self.moe is not None:
+        if self.mlp is not None:
             if not self.fused_add_norm:
                 residual = hidden_states + residual
                 hidden_states = self.norm2(residual.to(dtype=self.norm2.weight.dtype))
@@ -91,7 +85,7 @@ class Block(nn.Module):
                     eps=self.norm2.eps,
                     is_rms_norm=isinstance(self.norm2, RMSNorm)
                 )
-            hidden_states, _ = self.moe(hidden_states)
+            hidden_states = self.mlp(hidden_states)
 
         return hidden_states, residual
 

--- a/mamba_ssm/modules/block.py
+++ b/mamba_ssm/modules/block.py
@@ -9,7 +9,9 @@ from mamba_ssm.ops.triton.layer_norm import RMSNorm, layer_norm_fn
 
 class Block(nn.Module):
     def __init__(
-        self, dim, mixer_cls, mlp_cls, norm_cls=nn.LayerNorm, fused_add_norm=False, residual_in_fp32=False
+        self, dim, mixer_cls, mlp_cls, 
+        moe_cls=None,
+        norm_cls=nn.LayerNorm, fused_add_norm=False, residual_in_fp32=False
     ):
         """
         Simple block wrapping a mixer class with LayerNorm/RMSNorm and residual connection"
@@ -33,6 +35,12 @@ class Block(nn.Module):
             self.mlp = mlp_cls(dim)
         else:
             self.mlp = None
+
+        # hack in the MoE
+        if moe_cls:
+            self.norm2 = norm_cls(dim)
+            self.moe = moe_cls()
+
         if self.fused_add_norm:
             assert RMSNorm is not None, "RMSNorm import fails"
             assert isinstance(
@@ -66,7 +74,7 @@ class Block(nn.Module):
             )
         hidden_states = self.mixer(hidden_states, inference_params=inference_params, **mixer_kwargs)
 
-        if self.mlp is not None:
+        if self.moe is not None:
             if not self.fused_add_norm:
                 residual = hidden_states + residual
                 hidden_states = self.norm2(residual.to(dtype=self.norm2.weight.dtype))
@@ -83,7 +91,7 @@ class Block(nn.Module):
                     eps=self.norm2.eps,
                     is_rms_norm=isinstance(self.norm2, RMSNorm)
                 )
-            hidden_states = self.mlp(hidden_states)
+            hidden_states, _ = self.moe(hidden_states)
 
         return hidden_states, residual
 

--- a/mamba_ssm/utils/hf.py
+++ b/mamba_ssm/utils/hf.py
@@ -15,7 +15,7 @@ def load_state_dict_hf(model_name, device=None, dtype=None):
     # If not fp32, then we don't want to load directly to the GPU
     mapped_device = "cpu" if dtype not in [torch.float32, None] else device
     resolved_archive_file = cached_file(model_name, WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False)
-    return torch.load(resolved_archive_file, map_location=mapped_device)
+    return torch.load(resolved_archive_file, map_location=mapped_device, weights_only=True)
     # Convert dtype before moving to GPU to save memory
     if dtype is not None:
         state_dict = {k: v.to(dtype=dtype) for k, v in state_dict.items()}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,30 @@
+#!bin/bash
+
+run() {
+
+    local DISABLE_SCATTERMOE=${1:-"False"}
+    local N_EXPERT=${2:-2}
+    
+    DISABLE_SCATTERMOE=$DISABLE_SCATTERMOE \
+    torchrun --nnodes=1 --node_rank=0 \
+        --nproc_per_node=$N_EXPERT --rdzv_id=101 \
+        --rdzv_endpoint="localhost:27501" \
+        -m train \
+        --model_name /home/flim/data/Bamba-9b-2.3T \
+        --per_device_train_batch_size 8 \
+        --low_cpu_mem_mode true \
+        --n_expert $N_EXPERT \
+        --max_seq_length 128
+}
+
+LOG_DIR=exprs
+
+mkdir -p $LOG_DIR
+
+TAG="kernels"
+for disable in "False" "True" ; do
+    for ne in 2 4 8 ; do
+        NAME=$LOG_DIR/${TAG}_${disable}_${ne}
+        run $disable $ne 1> $NAME.log 2> $NAME.err
+    done
+done

--- a/train.py
+++ b/train.py
@@ -5,7 +5,14 @@ from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel, MambaConfig
 from torch.distributed.tensor import init_device_mesh
 from transformers.loss.loss_utils import ForCausalLMLoss
 from transformers.models.granitemoe.modeling_granitemoe import load_balancing_loss_func
+from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    FullyShardedDataParallel as FSDP,
+    ShardingStrategy,
+    BackwardPrefetch
+)
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.optim import AdamW
+from functools import partial
 
 # hack in a section in the config
 # "mlp_cfg": {
@@ -22,6 +29,13 @@ def main(
     learning_rate: float = 1e-4,
 ):
 
+    world_size = int(os.environ.get('WORLD_SIZE', 1))
+    rank = int(os.environ.get('RANK', 0))
+
+    if world_size > 1:
+        torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
+        torch.cuda.set_device(rank)
+
     model = MambaLMHeadModel.from_pretrained(
         model_name,
         device=device,
@@ -29,11 +43,14 @@ def main(
     )
     model.train()
 
-    # - create optimizer (after sharding)
-    optimizer = AdamW(model.parameters(), lr=learning_rate)
+    # for i, block in enumerate(model.backbone.layers):
+    #     from torch.distributed.algorithms._checkpoint import checkpoint_wrapper
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import apply_activation_checkpointing
+    from mamba_ssm.modules.block import Block
+    apply_activation_checkpointing(
+        model, check_fn=lambda mod: isinstance(mod, Block)
+    )
 
-    world_size = int(os.environ.get('WORLD_SIZE', 1))
-    rank = int(os.environ.get('RANK', 0))
 
     device_mesh = None
     if world_size > 1:
@@ -41,6 +58,30 @@ def main(
             device, 
             (world_size,), mesh_dim_names=('data_parallel', )
         )
+
+        # mamba_ssm will keep D params in float32, which will cause 
+        # problems
+        for name, param in model.named_parameters():
+            if str(param.dtype) != f"torch.{dtype}":
+                param.data = param.data.to(getattr(torch, dtype))
+
+        # lazy to use FSDP2, use FSDP1 for now
+        model = FSDP(
+            model,
+            sharding_strategy=ShardingStrategy.FULL_SHARD,
+            backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
+            ignored_modules=None,
+            use_orig_params=False,
+            forward_prefetch=False,
+            auto_wrap_policy=partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={Block},
+            ),
+            device_id=rank,
+        )
+
+    # - create optimizer (after sharding)
+    optimizer = AdamW(model.parameters(), lr=learning_rate)
 
     # some easy to debug dummy data
     input_ids = torch.ones(
@@ -51,7 +92,7 @@ def main(
     labels = input_ids
 
     ave_loss = 0.
-    for step in trange(total_train_steps):
+    for step in trange(total_train_steps, disable=rank>0):
         optimizer.zero_grad()
         out = model(input_ids)
         loss = ForCausalLMLoss(

--- a/train.py
+++ b/train.py
@@ -28,6 +28,7 @@ def main(
     max_seq_length: int = 128,
     learning_rate: float = 1e-4,
     print_itvl: int = 20,
+    low_cpu_mem_mode: bool = False,
 ):
 
     world_size = int(os.environ.get('WORLD_SIZE', 1))
@@ -37,11 +38,26 @@ def main(
         torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
         torch.cuda.set_device(rank)
 
-    model = MambaLMHeadModel.from_pretrained(
-        model_name,
-        device=device,
-        dtype=getattr(torch, dtype)
-    )
+
+    from accelerate.big_modeling import init_empty_weights, init_on_device
+
+    if not low_cpu_mem_mode:
+        # from contextlib import nullcontext
+        loading_context = partial(init_on_device, device=device)
+    elif rank == 0:
+        loading_context = partial(init_on_device, device='cpu')
+    else:
+        loading_context = partial(init_empty_weights, include_buffers=False)
+
+    with loading_context():
+        # TODO: weight initialization not done properly
+        # need to pass in initializer_cfg to init the weights
+        model = MambaLMHeadModel.from_pretrained(
+            model_name,
+            dtype=getattr(torch, dtype),
+            low_cpu_mem_mode=rank > 0 and low_cpu_mem_mode,
+        )
+
     model.train()
 
     from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import apply_activation_checkpointing
@@ -64,12 +80,23 @@ def main(
             if str(param.dtype) != f"torch.{dtype}":
                 param.data = param.data.to(getattr(torch, dtype))
 
+        # somehow the buffers in RotaryEmb causing alot of problems
+        # - so we need to ignore them in FSDP
+        # - also we delete the buffers and just attach them as tensors and 
+        #  move them to device manually
+        for name, mod in model.named_modules():
+            if 'rotary_emb' in name:
+                inv_freq = mod._buffers['inv_freq']
+                del mod._buffers['inv_freq']
+                mod.inv_freq = inv_freq.to(device)
+
+        from accelerate.utils.fsdp_utils import ensure_weights_retied
+
         # lazy to use FSDP2, use FSDP1 for now
         model = FSDP(
             model,
             sharding_strategy=ShardingStrategy.FULL_SHARD,
             backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
-            ignored_modules=None,
             use_orig_params=False,
             forward_prefetch=False,
             auto_wrap_policy=partial(
@@ -77,11 +104,26 @@ def main(
                 transformer_layer_cls={Block},
             ),
             device_id=rank,
+            sync_module_states=True,
+            param_init_fn=(
+                None if rank == 0 else ensure_weights_retied(
+                    lambda x: x.to_empty(device=device), 
+                    model,
+                    device
+                )
+            ),
+            ignored_modules=[
+                p for name, p in model.named_modules()
+                if 'rotary_emb' in name
+            ]
         )
-    
+
     if rank == 0:
         # print for debug
         print(model)
+        print ("Number parameters per device: ", sum([p.numel() for p in model.parameters()]))
+        torch.cuda.empty_cache()
+        print ("Memory after model loading", torch.cuda.memory_allocated())
 
     # - create optimizer (after sharding)
     optimizer = AdamW(model.parameters(), lr=learning_rate)
@@ -98,10 +140,13 @@ def main(
     for step in trange(total_train_steps, disable=rank>0):
         optimizer.zero_grad()
         out = model(input_ids)
+
+        if rank == 0 and step == 0:
+            print ("Memory after model forward", torch.cuda.memory_allocated())
+
         loss = ForCausalLMLoss(
             out.logits, labels, out.logits.shape[-1]
         )
-
 
         if out.aux_outputs is not None:
             aux_loss = load_balancing_loss_func(
@@ -117,6 +162,8 @@ def main(
         )
 
         loss.backward()
+        if rank == 0 and step == 0:
+            print ("Memory after model backward", torch.cuda.memory_allocated())
         optimizer.step()
 
         if rank == 0 and (step % print_itvl) == 0:

--- a/train.py
+++ b/train.py
@@ -27,6 +27,7 @@ def main(
     per_device_train_batch_size: int = 4,
     max_seq_length: int = 128,
     learning_rate: float = 1e-4,
+    print_itvl: int = 20,
 ):
 
     world_size = int(os.environ.get('WORLD_SIZE', 1))
@@ -43,17 +44,15 @@ def main(
     )
     model.train()
 
-    # for i, block in enumerate(model.backbone.layers):
-    #     from torch.distributed.algorithms._checkpoint import checkpoint_wrapper
     from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import apply_activation_checkpointing
     from mamba_ssm.modules.block import Block
     apply_activation_checkpointing(
         model, check_fn=lambda mod: isinstance(mod, Block)
     )
 
-
     device_mesh = None
     if world_size > 1:
+        # TODO: add device mesh to ScatterMoE
         device_mesh = init_device_mesh(
             device, 
             (world_size,), mesh_dim_names=('data_parallel', )
@@ -79,6 +78,10 @@ def main(
             ),
             device_id=rank,
         )
+    
+    if rank == 0:
+        # print for debug
+        print(model)
 
     # - create optimizer (after sharding)
     optimizer = AdamW(model.parameters(), lr=learning_rate)
@@ -116,10 +119,10 @@ def main(
         loss.backward()
         optimizer.step()
 
-        print ({"step": step+1, "loss": ave_loss})
+        if rank == 0 and (step % print_itvl) == 0:
+            print ({"step": step+1, "loss": ave_loss})
 
 
 if __name__ == '__main__':
-    # import fire
-    # fire.Fire(main)
-    main()
+    import fire
+    fire.Fire(main)

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
     ShardingStrategy,
     BackwardPrefetch
 )
+import time
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.optim import AdamW
 from functools import partial
@@ -29,6 +30,9 @@ def main(
     learning_rate: float = 1e-4,
     print_itvl: int = 20,
     low_cpu_mem_mode: bool = False,
+    n_expert: int = 2,
+    freeze_data: bool = True,
+    warmup_steps: int = 10,
 ):
 
     world_size = int(os.environ.get('WORLD_SIZE', 1))
@@ -52,10 +56,18 @@ def main(
     with loading_context():
         # TODO: weight initialization not done properly
         # need to pass in initializer_cfg to init the weights
+
+        # config_kwargs will be passed to config
         model = MambaLMHeadModel.from_pretrained(
             model_name,
             dtype=getattr(torch, dtype),
             low_cpu_mem_mode=rank > 0 and low_cpu_mem_mode,
+            config_kwargs={
+                "mlp_cfg": {
+                    "n_expert": n_expert,
+                    "load_balancing_loss": True
+                }
+            }
         )
 
     model.train()
@@ -118,42 +130,72 @@ def main(
             ]
         )
 
+    stats = {}
     if rank == 0:
         # print for debug
         print(model)
-        print ("Number parameters per device: ", sum([p.numel() for p in model.parameters()]))
+        # print ("Number parameters per device: ", sum([p.numel() for p in model.parameters()]))
+        stats['num_parameters'] = sum([p.numel() for p in model.parameters()])
         torch.cuda.empty_cache()
-        print ("Memory after model loading", torch.cuda.memory_allocated())
+        stats['memory_after_model_load'] = torch.cuda.memory_allocated()
+        # print ("Memory after model loading", torch.cuda.memory_allocated())
 
     # - create optimizer (after sharding)
     optimizer = AdamW(model.parameters(), lr=learning_rate)
 
-    # some easy to debug dummy data
-    input_ids = torch.ones(
-        (per_device_train_batch_size, max_seq_length), 
-        dtype=torch.long, 
-        device=device,
-    )
-    labels = input_ids
+    def generate_data(static: bool = False):
+
+        func = (
+            partial(torch.randint, high=model.config.vocab_size)
+            if not static else torch.ones
+        )
+        # some easy to debug dummy data
+        input_ids = func(
+            size=(per_device_train_batch_size, max_seq_length), 
+            dtype=torch.long, 
+            device=device,
+        )
+        labels = input_ids
+        return input_ids, labels
+
+    assert warmup_steps < total_train_steps
 
     ave_loss = 0.
     for step in trange(total_train_steps, disable=rank>0):
+
+        if (
+            (freeze_data and step==0) or not freeze_data
+        ):
+            input_ids, labels = generate_data()
+
+        if rank == 0 and step == warmup_steps:
+            t1 = time.time()
+
         optimizer.zero_grad()
         out = model(input_ids)
 
         if rank == 0 and step == 0:
-            print ("Memory after model forward", torch.cuda.memory_allocated())
+            # print ("Memory after model forward", torch.cuda.memory_allocated())
+            stats['memory_after_model_forward'] = torch.cuda.memory_allocated()
 
         loss = ForCausalLMLoss(
             out.logits, labels, out.logits.shape[-1]
         )
 
+        distribution = None
         if out.aux_outputs is not None:
+            top_k = model.config.mlp_cfg.get('top_k',2)
             aux_loss = load_balancing_loss_func(
                 out.aux_outputs, 
                 num_experts=model.config.mlp_cfg['n_expert'],
-                top_k=model.config.mlp_cfg.get('top_k',2)
+                top_k=top_k,
             )
+
+            # just do on the top
+            _, distribution = out.aux_outputs[0].topk(
+                top_k
+            ).indices.unique(return_counts=True)
+            distribution = distribution.detach().cpu().tolist()
 
             loss += 0.2 * aux_loss
 
@@ -163,12 +205,20 @@ def main(
 
         loss.backward()
         if rank == 0 and step == 0:
-            print ("Memory after model backward", torch.cuda.memory_allocated())
+            # print ("Memory after model backward", torch.cuda.memory_allocated())
+            stats['memory_after_model_backward'] = torch.cuda.memory_allocated()
+
         optimizer.step()
 
         if rank == 0 and (step % print_itvl) == 0:
-            print ({"step": step+1, "loss": ave_loss})
+            print ({"step": step+1, "loss": ave_loss, "distribution": distribution})
 
+    torch.cuda.synchronize()
+
+    if rank == 0:
+        t1 = time.time() - t1
+        stats['time_taken'] = t1
+        print (stats)
 
 if __name__ == '__main__':
     import fire

--- a/train.py
+++ b/train.py
@@ -1,0 +1,84 @@
+import os
+import torch
+from tqdm import trange
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel, MambaConfig
+from torch.distributed.tensor import init_device_mesh
+from transformers.loss.loss_utils import ForCausalLMLoss
+from transformers.models.granitemoe.modeling_granitemoe import load_balancing_loss_func
+from torch.optim import AdamW
+
+# hack in a section in the config
+# "mlp_cfg": {
+#       "n_expert": 4,
+#       "load_balancing_loss": true
+#   }
+def main(
+    model_name='/home/flim/data/mamba2-370m',
+    dtype: str='bfloat16',
+    device: str='cuda',
+    total_train_steps: int = 100,
+    per_device_train_batch_size: int = 4,
+    max_seq_length: int = 128,
+    learning_rate: float = 1e-4,
+):
+
+    model = MambaLMHeadModel.from_pretrained(
+        model_name,
+        device=device,
+        dtype=getattr(torch, dtype)
+    )
+    model.train()
+
+    # - create optimizer (after sharding)
+    optimizer = AdamW(model.parameters(), lr=learning_rate)
+
+    world_size = int(os.environ.get('WORLD_SIZE', 1))
+    rank = int(os.environ.get('RANK', 0))
+
+    device_mesh = None
+    if world_size > 1:
+        device_mesh = init_device_mesh(
+            device, 
+            (world_size,), mesh_dim_names=('data_parallel', )
+        )
+
+    # some easy to debug dummy data
+    input_ids = torch.ones(
+        (per_device_train_batch_size, max_seq_length), 
+        dtype=torch.long, 
+        device=device,
+    )
+    labels = input_ids
+
+    ave_loss = 0.
+    for step in trange(total_train_steps):
+        optimizer.zero_grad()
+        out = model(input_ids)
+        loss = ForCausalLMLoss(
+            out.logits, labels, out.logits.shape[-1]
+        )
+
+
+        if out.aux_outputs is not None:
+            aux_loss = load_balancing_loss_func(
+                out.aux_outputs, 
+                num_experts=model.config.mlp_cfg['n_expert'],
+                top_k=model.config.mlp_cfg.get('top_k',2)
+            )
+
+            loss += 0.2 * aux_loss
+
+        ave_loss = (
+            step / (step+1) * ave_loss + loss.detach().item() / (step + 1)
+        )
+
+        loss.backward()
+        optimizer.step()
+
+        print ({"step": step+1, "loss": ave_loss})
+
+
+if __name__ == '__main__':
+    # import fire
+    # fire.Fire(main)
+    main()


### PR DESCRIPTION
This PR provides
- integrating `scattermoe` as an drop-in replacemnet for the MLP.

Dependencies: we take the ScatterMoE impl from `fms-acceleration`
```
pip install fms-acceleration
pip install fms-acceleration-moe
pip install "kernel-hyperdrive @ git+https://github.com/fabianlim/kernel-hyperdrive.git"
```

We have a training script for testing (that uses FSDP1):

```
CUDA_VISIBLE_DEVICES="0,1" \
DISABLE_SCATTERMOE=True \
torchrun --nnodes=1 --node_rank=0 \
	--nproc_per_node=2 --rdzv_id=101 \
	--rdzv_endpoint="localhost:27500" \
	-m train --model_name ... \
    --per_device_train_batch_size 16
```

Note: 
- to activate the `scatterMoE` have to modify the `config.json` to have this additional stanza
   ```json
   "mlp_cfg": {
        "n_expert": 2,
        "load_balancing_loss": true
    },
   ```
- if `DISABLE_SCATTERMOE=True` then will replace the MoE with the `GraniteMoE` serial implementation 


## Isolated Benchmarks

See `benchmark.py`, these are just random data with a single `nn.Module`:

`d_model: 1536, d_intermediate: 512, n_expert:  [10, 20, 30, 40]: top_k: 8`
![image](https://github.com/user-attachments/assets/2b337af6-4d54-4148-a01c-c86747f5d5a4)


`d_model: 4096, d_intermediate: 14336, n_expert: [2, 4, 8, 16], top_k: 2`

![image](https://github.com/user-attachments/assets/092da6c7-fae3-4abe-8ea7-33bb8be673b0)


## Actual Runs

- `n_expert=8` means we add 8 experts, `num_parameters` are per device (sharded) numbers
- `kernels` are FSDP-only runs, no EP sharding just replacing the naive MoE with the ScatterMoE kernel

|    | num_parameters   | memory_after_model_load   | memory_after_model_forward   | memory_after_model_backward   |   time_taken | tag     | scattermoe   |   n_expert |
|---:|:-----------------|:--------------------------|:-----------------------------|:------------------------------|-------------:|:--------|:-------------|-----------:|
|  5 | 7.71 G           | 16.48 G                   | 19.69 G                      | 32.24 G                       |      76.8429 | kernels | False        |          2 |
|  5 | 7.71 G           | 16.48 G                   | 19.69 G                      | 32.24 G                       |      87.1154 | kernels | True         |          2 |
|  5 | 6.67 G           | 14.40 G                   | 17.61 G                      | 28.07 G                       |     119.401  | kernels | False        |          4 |
|  5 | 6.67 G           | 14.40 G                   | 17.61 G                      | 28.07 G                       |     102.311  | kernels | True         |          4 |
|  5 | 6.16 G           | 13.36 G                   | 16.57 G                      | 26.00 G                       |     642.909  | kernels | False        |          8 |
|  5 | 6.16 G           | 13.36 G                   | 16.57 G                      | 26.00 G                       |     448.44   | kernels | True         |          8 |
