### PR TITLE
Expert Parallel

### DIFF
--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -53,6 +53,7 @@ def create_block(
     fused_add_norm=False,
     layer_idx=None,
     device=None,
+    device_mesh=None,
     dtype=None,
 ):
     if ssm_cfg is None:
@@ -107,19 +108,34 @@ def create_block(
                     "To renable requires reload of module."
                 )
 
+            # NOTE: in the case where expert parallel is > 1
+            # i.e., when device_mesh.size() > 1 this is slighly incorrect
+            # logic, because this causes the router to be sharded,
+            # which is wrong because it has to function for the 
+            # global number of routers
+
+            num_experts_per_device = (
+                mlp_cfg['n_expert'] if device_mesh is None
+                else
+                mlp_cfg['n_expert'] // device_mesh.size()
+            )
+
             mlp_cls = partial(
                 ScatterMoE,
                 # hidden_size=d_model,
                 hidden_act='silu',
                 # intermediate_size=int(8* d_model / 3),
                 intermediate_size=d_intermediate,
-                num_experts=mlp_cfg['n_expert'],
+                num_experts=num_experts_per_device,
                 has_bias=False, # hardcode this, scattermoe cannot work with bias
                 mlp_arch=SCATTERMOE_SPEC_HAS_GATE, # hardcode this, use gated
                 top_k=mlp_cfg.get('top_k', 2),
-                **factory_kwargs
+                **factory_kwargs,
+                ep_device_mesh=device_mesh,
             )
         else:
+            assert device_mesh is None, "expert parallel requires ScatterMoe"
+
             # NOTE: just for benching against a naive 
             # MoE implementation, not to be used for
             # real training
@@ -205,6 +221,7 @@ class MixerModel(nn.Module):
         fused_add_norm=False,
         residual_in_fp32=False,
         device=None,
+        device_mesh=None,
         dtype=None,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
@@ -237,6 +254,7 @@ class MixerModel(nn.Module):
                     fused_add_norm=fused_add_norm,
                     layer_idx=i,
                     mlp_cfg=mlp_cfg,
+                    device_mesh=device_mesh,
                     **factory_kwargs,
                 )
                 for i in range(n_layer)
@@ -247,14 +265,14 @@ class MixerModel(nn.Module):
             d_model, eps=norm_epsilon, **factory_kwargs
         )
 
-        self.apply(
-            partial(
-                _init_weights,
-                n_layer=n_layer,
-                **(initializer_cfg if initializer_cfg is not None else {}),
-                n_residuals_per_layer=1 if d_intermediate == 0 else 2,  # 2 if we have MLP
-            )
-        )
+        # self.apply(
+        #     partial(
+        #         _init_weights,
+        #         n_layer=n_layer,
+        #         **(initializer_cfg if initializer_cfg is not None else {}),
+        #         n_residuals_per_layer=1 if d_intermediate == 0 else 2,  # 2 if we have MLP
+        #     )
+        # )
 
     def allocate_inference_cache(self, batch_size, max_seqlen, dtype=None, **kwargs):
         return {
@@ -303,6 +321,7 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         config: MambaConfig,
         initializer_cfg=None,
         device=None,
+        device_mesh=None,
         dtype=None,
     ) -> None:
         self.config = config
@@ -336,18 +355,19 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
             initializer_cfg=initializer_cfg,
             fused_add_norm=fused_add_norm,
             residual_in_fp32=residual_in_fp32,
+            device_mesh=device_mesh,
             **factory_kwargs,
         )
         self.lm_head = nn.Linear(d_model, vocab_size, bias=False, **factory_kwargs)
 
         # Initialize weights and apply final processing
-        self.apply(
-            partial(
-                _init_weights,
-                n_layer=n_layer,
-                **(initializer_cfg if initializer_cfg is not None else {}),
-            )
-        )
+        # self.apply(
+        #     partial(
+        #         _init_weights,
+        #         n_layer=n_layer,
+        #         **(initializer_cfg if initializer_cfg is not None else {}),
+        #     )
+        # )
         self.tie_weights()
 
     def tie_weights(self):

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,7 @@ run() {
 
     local DISABLE_SCATTERMOE=${1:-"False"}
     local N_EXPERT=${2:-2}
+    local EP_DEGREE=${3:-1}
     
     DISABLE_SCATTERMOE=$DISABLE_SCATTERMOE \
     torchrun --nnodes=1 --node_rank=0 \
@@ -14,6 +15,7 @@ run() {
         --per_device_train_batch_size 8 \
         --low_cpu_mem_mode true \
         --n_expert $N_EXPERT \
+        --ep_degree $EP_DEGREE \
         --max_seq_length 128
 }
 
@@ -21,10 +23,9 @@ LOG_DIR=exprs
 
 mkdir -p $LOG_DIR
 
-TAG="kernels"
-for disable in "False" "True" ; do
-    for ne in 2 4 8 ; do
-        NAME=$LOG_DIR/${TAG}_${disable}_${ne}
-        run $disable $ne 1> $NAME.log 2> $NAME.err
-    done
+
+TAG="expert_parallel"
+for ne in 2 4 8 ; do
+    NAME=$LOG_DIR/${TAG}_${ne}_${ne}
+    run False $ne $ne 1> $NAME.log 2> $NAME.err
 done

--- a/train.py
+++ b/train.py
@@ -2,7 +2,7 @@ import os
 import torch
 from tqdm import trange
 from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel, MambaConfig
-from torch.distributed.tensor import init_device_mesh
+from torch.distributed.tensor import init_device_mesh, DeviceMesh
 from transformers.loss.loss_utils import ForCausalLMLoss
 from transformers.models.granitemoe.modeling_granitemoe import load_balancing_loss_func
 from torch.distributed.fsdp.fully_sharded_data_parallel import (
@@ -14,6 +14,57 @@ import time
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.optim import AdamW
 from functools import partial
+
+from torch.distributed.tensor import DTensor, Replicate, Shard, distribute_tensor
+from collections import OrderedDict
+
+# taken from fms_acceleration_moe.utils.scattermoe_prepare.load_experts_onto_device
+def shard_scattermoe(
+    module: torch.nn.Module,
+    state_dict: OrderedDict,
+    device_mesh: DeviceMesh,
+    key_ep: str,
+    router_name: str = 'router',
+):
+    # hook for scaling the gradient
+    scaling = device_mesh[key_ep].size()
+
+    def _hook(grad):
+        if grad is not None:
+            grad.div_(scaling)
+        return grad
+
+    # required replication placements
+    reps = [Replicate() for _ in range(device_mesh.ndim - 1)]
+
+    for weight_name, param in state_dict.items():
+
+        if router_name in weight_name:
+            # if its the router, replicate
+            param = distribute_tensor(param, device_mesh, reps + [Replicate()])
+        else:
+            # if its a weight and the already sharded by number of experts
+            param = DTensor.from_local(
+                param, device_mesh=device_mesh, placements=reps + [Shard(0)]
+            )
+
+        # get the module we want to shard
+        name = weight_name.split(".")
+        path, name = ".".join(name[:-1]), name[-1]
+        mod = module.get_submodule(path)
+        requires_grad = getattr(mod, name).requires_grad
+
+        param = torch.nn.Parameter(
+            param,
+            requires_grad=requires_grad,
+        )
+
+        # install gradient scaling hook
+        if router_name not in weight_name:
+            param.register_hook(_hook)
+
+        # register the sharded parameter 
+        mod.register_parameter(name, param)
 
 # hack in a section in the config
 # "mlp_cfg": {
@@ -31,6 +82,7 @@ def main(
     print_itvl: int = 20,
     low_cpu_mem_mode: bool = False,
     n_expert: int = 2,
+    ep_degree: int = 1,
     freeze_data: bool = True,
     warmup_steps: int = 10,
 ):
@@ -42,6 +94,20 @@ def main(
         torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
         torch.cuda.set_device(rank)
 
+    # for the expert parallel
+    device_mesh = None
+    if world_size > 1 and ep_degree > 1:
+        # needed to shard
+        assert world_size % ep_degree == 0
+
+        # needed
+        assert n_expert % ep_degree == 0
+
+        device_mesh = init_device_mesh(
+            device, 
+            (world_size // ep_degree, ep_degree), 
+            mesh_dim_names=('data_parallel', 'expert_parallel')
+        )
 
     from accelerate.big_modeling import init_empty_weights, init_on_device
 
@@ -58,6 +124,8 @@ def main(
         # need to pass in initializer_cfg to init the weights
 
         # config_kwargs will be passed to config
+        # - device_mesh to be passed into MambaLMHeadModel's
+        #   constructor (to be used to load ScatterMoE)
         model = MambaLMHeadModel.from_pretrained(
             model_name,
             dtype=getattr(torch, dtype),
@@ -67,7 +135,8 @@ def main(
                     "n_expert": n_expert,
                     "load_balancing_loss": True
                 }
-            }
+            },
+            device_mesh=device_mesh['expert_parallel'],
         )
 
     model.train()
@@ -78,13 +147,68 @@ def main(
         model, check_fn=lambda mod: isinstance(mod, Block)
     )
 
-    device_mesh = None
     if world_size > 1:
-        # TODO: add device mesh to ScatterMoE
-        device_mesh = init_device_mesh(
-            device, 
-            (world_size,), mesh_dim_names=('data_parallel', )
-        )
+
+        # handle the scattermoe first
+        ignored_modules = []
+        if ep_degree > 1:
+            num_experts_per_degree = n_expert // ep_degree
+            idxs = list(
+                range(
+                    rank*num_experts_per_degree,  
+                    (rank+1)*num_experts_per_degree,  
+                )
+            )
+            for layer in model.backbone.layers:
+
+                mod = layer.mlp
+
+                # we need to manually shard the params
+                # NOTE: in the ep case, the linear router
+                # is sharded when it should not, so we recreate
+                # it
+                mod.router = torch.nn.Linear(
+                    in_features=mod.router.in_features,
+                    out_features=n_expert,
+                    bias=mod.router.bias is not None,
+                    device=mod.router.weight.device,
+                    dtype=mod.router.weight.dtype
+                )
+
+                # handle the state dict
+                sd = {
+                    name: (
+                        param
+                        if 'router' in name 
+                        else param[idxs]
+                    )
+                    for name, param in mod.named_parameters()
+                }
+
+                if low_cpu_mem_mode and rank > 0:
+                    # in this case, the router will be replicated
+                    # but the scattered experts need to be re-initialized
+                    # 
+                    for name in sd:
+                        param = sd[name]
+                        if 'router' in name:
+                            sd[name] = torch.empty_like(param, device='cpu')
+                        else:
+                            # NOTE: this is duplicated from _init_weights
+                            torch.nn.init.normal_(param, std=0.02)
+
+                # this will be the scattermoe
+                shard_scattermoe(
+                    mod, 
+                    sd,
+                    device_mesh,
+                    key_ep='expert_parallel',
+                    router_name='router',
+                )
+
+                # if there is EP, then the 
+                # the scattermoe will not be handled by FSDP
+                ignored_modules.append(mod)
 
         # mamba_ssm will keep D params in float32, which will cause 
         # problems
@@ -127,7 +251,7 @@ def main(
             ignored_modules=[
                 p for name, p in model.named_modules()
                 if 'rotary_emb' in name
-            ]
+            ] + ignored_modules
         )
 
     stats = {}
@@ -141,7 +265,13 @@ def main(
         # print ("Memory after model loading", torch.cuda.memory_allocated())
 
     # - create optimizer (after sharding)
-    optimizer = AdamW(model.parameters(), lr=learning_rate)
+    # NOTE: for ep we are mixing dtensors with shardedtensors (from FSDP 1)
+    # so we need to disable foreach
+    optimizer = AdamW(
+        model.parameters(), 
+        lr=learning_rate,
+        foreach=False if ep_degree > 1 else None,
+    )
 
     def generate_data(static: bool = False):
 


### PR DESCRIPTION
This adds expert parallel

## Experiments

- the difference with `kernels` and `expert_parallel` is the sharding of the MoE (FSDP1 vs EP)
- mamba + attn layers are always handled with FSDP1
- in both cases, `scattermoe` kernels are used.
- when increasing `n_expert`, an additional expert (of the same size) is simply added. One expert is equal in size to an MLP of the Bamba 9B

Known Issues
- mixing FSDP1 and EP (which uses `torch.distributed.tensors` (aka FSDP2) is not ideal

|    | memory_after_model_load   | memory_after_model_forward   | memory_after_model_backward   |   time_taken | tag             |   n_expert |   ep_degree |
|---:|:--------------------------|:-----------------------------|:------------------------------|-------------:|:----------------|-----------:|------------:|
|  5 | 16.48 G                   | 19.69 G                      | 32.24 G                       |      87.1154 | kernels         |          2 |           1 |
|  5 | 16.48 G                   | 19.70 G                      | 32.24 G                       |     121.957  | expert_parallel |          2 |           2 |
|  5 | 14.40 G                   | 17.61 G                      | 28.07 G                       |     102.311  | kernels         |          4 |           1 |
|  5 | 14.40 G                   | 17.61 G                      | 28.08 G                       |     125.857  | expert_parallel |          4 |           4 |
|  5 | 13.36 G                   | 16.57 G                      | 26.00 G                       |     448.44   | kernels         |          8 |           1 |
|  5 | 13.36 G                   | 16.58 G                      | 26.01 G                       |     220.252  | expert_parallel |          8 |           8 |
